### PR TITLE
Add missing from 2.0.2

### DIFF
--- a/php_sweph.h
+++ b/php_sweph.h
@@ -48,6 +48,7 @@ PHP_FUNCTION(swe_set_sid_mode);
 PHP_FUNCTION(swe_get_ayanamsa);
 PHP_FUNCTION(swe_get_ayanamsa_ut);
 PHP_FUNCTION(swe_get_ayanamsa_ex);
+PHP_FUNCTION(swe_get_ayanamsa_ex_ut);
 PHP_FUNCTION(swe_get_ayanamsa_name);
 PHP_FUNCTION(swe_version);
 PHP_FUNCTION(swe_get_library_path);

--- a/php_sweph.h
+++ b/php_sweph.h
@@ -107,6 +107,7 @@ PHP_FUNCTION(swe_nod_aps_ut);
  * exports from swephlib.c 
  ****************************/
 PHP_FUNCTION(swe_deltat);
+PHP_FUNCTION(swe_deltat_ex);
 PHP_FUNCTION(swe_time_equ);
 PHP_FUNCTION(swe_lmt_to_lat);
 PHP_FUNCTION(swe_lat_to_lmt);

--- a/php_sweph.h
+++ b/php_sweph.h
@@ -47,6 +47,7 @@ PHP_FUNCTION(swe_set_topo);
 PHP_FUNCTION(swe_set_sid_mode);
 PHP_FUNCTION(swe_get_ayanamsa);
 PHP_FUNCTION(swe_get_ayanamsa_ut);
+PHP_FUNCTION(swe_get_ayanamsa_ex);
 PHP_FUNCTION(swe_get_ayanamsa_name);
 PHP_FUNCTION(swe_version);
 PHP_FUNCTION(swe_get_library_path);

--- a/sweph.c
+++ b/sweph.c
@@ -48,6 +48,7 @@ zend_function_entry sweph_functions[] = {
 	PHP_FE(swe_set_sid_mode, NULL)
 	PHP_FE(swe_get_ayanamsa, NULL)
 	PHP_FE(swe_get_ayanamsa_ut, NULL)
+	PHP_FE(swe_get_ayanamsa_ex, NULL)
 	PHP_FE(swe_get_ayanamsa_name, NULL)
 	PHP_FE(swe_version, NULL)
 	PHP_FE(swe_get_library_path, NULL)
@@ -684,6 +685,27 @@ PHP_FUNCTION(swe_get_ayanamsa)
 	}
 	
 	RETURN_DOUBLE(swe_get_ayanamsa(tjd_et));
+}
+
+PHP_FUNCTION(swe_get_ayanamsa_ex)
+{
+	double tjd_et, daya;
+	long iflag;
+	char serr[AS_MAXCH];
+
+	if (ZEND_NUM_ARGS() != 2) WRONG_PARAM_COUNT;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dl",
+		&tjd_et, &iflag) == FAILURE) {
+		return;
+	}
+
+	swe_get_ayanamsa_ex(tjd_et, iflag, &daya, serr);
+
+    array_init(return_value);
+
+    add_assoc_double(return_value, "daya", daya);
+    add_assoc_string(return_value, "serr", serr);
 }
 
 PHP_FUNCTION(swe_get_ayanamsa_ut)

--- a/sweph.c
+++ b/sweph.c
@@ -49,6 +49,7 @@ zend_function_entry sweph_functions[] = {
 	PHP_FE(swe_get_ayanamsa, NULL)
 	PHP_FE(swe_get_ayanamsa_ut, NULL)
 	PHP_FE(swe_get_ayanamsa_ex, NULL)
+	PHP_FE(swe_get_ayanamsa_ex_ut, NULL)
 	PHP_FE(swe_get_ayanamsa_name, NULL)
 	PHP_FE(swe_version, NULL)
 	PHP_FE(swe_get_library_path, NULL)
@@ -720,6 +721,27 @@ PHP_FUNCTION(swe_get_ayanamsa_ut)
 	}
 	
 	RETURN_DOUBLE(swe_get_ayanamsa_ut(tjd_ut));
+}
+
+PHP_FUNCTION(swe_get_ayanamsa_ex_ut)
+{
+	double tjd_ut, daya;
+	long iflag;
+	char serr[AS_MAXCH];
+
+	if (ZEND_NUM_ARGS() != 2) WRONG_PARAM_COUNT;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dl",
+		&tjd_ut, &iflag) == FAILURE) {
+		return;
+	}
+
+	swe_get_ayanamsa_ex_ut(tjd_ut, iflag, &daya, serr);
+
+    array_init(return_value);
+
+    add_assoc_double(return_value, "daya", daya);
+    add_assoc_string(return_value, "serr", serr);
 }
 
 PHP_FUNCTION(swe_get_ayanamsa_name)

--- a/sweph.c
+++ b/sweph.c
@@ -104,6 +104,7 @@ zend_function_entry sweph_functions[] = {
 	 * exports from swephlib.c 
 	 ****************************/
 	PHP_FE(swe_deltat, NULL)
+	PHP_FE(swe_deltat_ex, NULL)
 	PHP_FE(swe_time_equ, NULL)
 	PHP_FE(swe_lmt_to_lat, NULL)
 	PHP_FE(swe_lat_to_lmt, NULL)
@@ -2017,6 +2018,27 @@ PHP_FUNCTION(swe_deltat)
 	}
 
 	RETURN_DOUBLE(swe_deltat(tjd_ut));
+}
+
+PHP_FUNCTION(swe_deltat_ex)
+{
+	double tjd_ut, tjd_et;
+	long ephe_flag;
+	char serr[AS_MAXCH];
+
+	if (ZEND_NUM_ARGS() != 2) WRONG_PARAM_COUNT;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dl",
+			&tjd_ut, &ephe_flag) == FAILURE) {
+		return;
+	}
+
+	tjd_et = swe_deltat_ex(tjd_ut, ephe_flag, serr);
+
+	array_init(return_value);
+
+	add_assoc_double(return_value, "tjd_et", tjd_et);
+	add_assoc_string(return_value, "serr", serr);
 }
 
 PHP_FUNCTION(swe_time_equ)


### PR DESCRIPTION
Refs: https://www.astro.com/swisseph/swephprg.htm#_Toc49847984

The following methods were not implemented in the extension since introduced in Swiss Ephemeris 2.0.2:

- swe_deltat_ex()
- swe_get_ayanamsa_ex()
- swe_get_ayanamsa_ex_ut()
