### PR TITLE
Fix swe_rise_trans() implementation.

### DIFF
--- a/sweph.c
+++ b/sweph.c
@@ -1869,38 +1869,28 @@ PHP_FUNCTION(swe_rise_trans)
 	char *arg = NULL;
 	int arg_len, rc, s_len;
 	long ipl, epheflag, rsmi;
-	double tjd_ut, geopos[3], tret[10], atpress, attemp;
-	char serr[AS_MAXCH], *starname = NULL; 
-	int i;
-	zval tret_arr;
+	double tjd_ut, geopos[3], tret, atpress, attemp;
+	char serr[AS_MAXCH], *starname = NULL;
 
 	if(ZEND_NUM_ARGS() != 10) WRONG_PARAM_COUNT;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dlsllddddd",
 			&tjd_ut, &ipl, &starname, &s_len, &epheflag, &rsmi,
-			&(geopos[0]), &(geopos[1]), &(geopos[2]),
+			&geopos[0], &geopos[1], &geopos[2],
 			&atpress, &attemp, 
 			&arg_len) == FAILURE) {
 		return;
 	}
-	rc = swe_rise_trans(tjd_ut, ipl, starname, epheflag, rsmi,
-			&(geopos[0]), atpress, attemp, tret, serr);
+
+	rc = swe_rise_trans(tjd_ut, ipl, starname, epheflag, rsmi, geopos, atpress, attemp, &tret, serr);
 
 	array_init(return_value);
 	add_assoc_long(return_value, "retflag", rc);
 
-	if (rc == ERR)
-	{
+	if (rc == ERR) {
 		add_assoc_string(return_value, "serr", serr);			
-	}
-	else
-	{
-		array_init(&tret_arr);
-		
-		for(i = 0; i < 10; i++)
-			add_index_double(&tret_arr, i, tret[i]);
-			
-		add_assoc_zval(return_value, "tret", &tret_arr);
+	} else {
+	    add_assoc_double(return_value, "tret", tret);
 	}
 }
 

--- a/sweph.c
+++ b/sweph.c
@@ -1895,21 +1895,18 @@ PHP_FUNCTION(swe_rise_trans)
 
 PHP_FUNCTION(swe_rise_trans_true_hor)
 {
-	char *arg = NULL;
-	int arg_len, rc, s_len;
+	int rc;
+	size_t s_len;
 	long ipl, epheflag, rsmi;
 	double tjd_ut, geopos[3], tret, atpress, attemp, horhgt;
-	char serr[AS_MAXCH], *starname = NULL; 
-	int i;
-	zval tret_arr;
+	char serr[AS_MAXCH], *starname = NULL;
 
 	if(ZEND_NUM_ARGS() != 11) WRONG_PARAM_COUNT;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dlslldddddd",
 			&tjd_ut, &ipl, &starname, &s_len, &epheflag, &rsmi,
 			&geopos[0], &geopos[1], &geopos[2],
-			&atpress, &attemp, &horhgt,
-			&arg_len) == FAILURE) {
+			&atpress, &attemp, &horhgt) == FAILURE) {
 		return;
 	}
 	rc = swe_rise_trans_true_hor(tjd_ut, ipl, starname, epheflag, rsmi,

--- a/sweph.c
+++ b/sweph.c
@@ -1866,19 +1866,18 @@ PHP_FUNCTION(swe_azalt_rev)
 
 PHP_FUNCTION(swe_rise_trans)
 {
-	char *arg = NULL;
-	int arg_len, rc, s_len;
+	int rc;
+	size_t s_len;
 	long ipl, epheflag, rsmi;
 	double tjd_ut, geopos[3], tret, atpress, attemp;
 	char serr[AS_MAXCH], *starname = NULL;
 
-	if(ZEND_NUM_ARGS() != 10) WRONG_PARAM_COUNT;
+	if (ZEND_NUM_ARGS() != 10) WRONG_PARAM_COUNT;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dlsllddddd",
 			&tjd_ut, &ipl, &starname, &s_len, &epheflag, &rsmi,
 			&geopos[0], &geopos[1], &geopos[2],
-			&atpress, &attemp, 
-			&arg_len) == FAILURE) {
+			&atpress, &attemp) == FAILURE) {
 		return;
 	}
 

--- a/sweph.c
+++ b/sweph.c
@@ -1898,7 +1898,7 @@ PHP_FUNCTION(swe_rise_trans_true_hor)
 	char *arg = NULL;
 	int arg_len, rc, s_len;
 	long ipl, epheflag, rsmi;
-	double tjd_ut, geopos[3], tret[10], atpress, attemp, horhgt;
+	double tjd_ut, geopos[3], tret, atpress, attemp, horhgt;
 	char serr[AS_MAXCH], *starname = NULL; 
 	int i;
 	zval tret_arr;
@@ -1913,24 +1913,16 @@ PHP_FUNCTION(swe_rise_trans_true_hor)
 		return;
 	}
 	rc = swe_rise_trans_true_hor(tjd_ut, ipl, starname, epheflag, rsmi,
-			geopos, atpress, attemp, horhgt, tret, serr);
+			geopos, atpress, attemp, horhgt, &tret, serr);
 
-	array_init(return_value);
-	add_assoc_long(return_value, "retflag", rc);
+    array_init(return_value);
+    add_assoc_long(return_value, "retflag", rc);
 
-	if (rc == ERR)
-	{
-		add_assoc_string(return_value, "serr", serr);			
-	}
-	else
-	{
-		array_init(&tret_arr);
-		
-		for(i = 0; i < 10; i++)
-			add_index_double(&tret_arr, i, tret[i]);
-			
-		add_assoc_zval(return_value, "tret", &tret_arr);
-	}
+    if (rc == ERR) {
+        add_assoc_string(return_value, "serr", serr);
+    } else {
+        add_assoc_double(return_value, "tret", tret);
+    }
 }
 
 PHP_FUNCTION(swe_nod_aps)


### PR DESCRIPTION
Refs: #6 

- [x] The current implementation returns an array of 10 doubles, whereas the SE docs clearly state the return value should simply be one (1) double: https://www.astro.com/swisseph/swephprg.htm#_Toc62644196
- [x] For some reason, the `ipl` parameter isn't getting parsed correctly. Somehow its value is always zero (`0`), which results in calculations only being performed on the Sun.
- [x] Audit and fix `swe_rise_trans_true_hor()` as needed.
